### PR TITLE
(cypress) Pass data feed reporter concurrency to reporter

### DIFF
--- a/aggregator/Chart.yaml
+++ b/aggregator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/aggregator/Chart.yaml
+++ b/aggregator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/aggregator/templates/reporter/deployment-reporter.yaml
+++ b/aggregator/templates/reporter/deployment-reporter.yaml
@@ -102,6 +102,8 @@ spec:
                   key: PROVIDER_URL
             - name: REPORTER_PORT
               value: {{ .Values.reporter.APP_PORT | default 6000 | int  }}
+            - name: DATA_FEED_REPORTER_CONCURRENCY
+              value: "20"
           {{ else }}
           env:
             - name: NODE_ENV
@@ -145,6 +147,8 @@ spec:
               value: "6000"
             - name: HEALTH_CHECK_PORT
               value: "8080"
+            - name: DATA_FEED_REPORTER_CONCURRENCY
+              value: "20"
           {{ end }}
           command: ["yarn"]
           args: [start:reporter:data_feed]

--- a/vrf/templates/reporter/deployment-reporter.yaml
+++ b/vrf/templates/reporter/deployment-reporter.yaml
@@ -136,8 +136,6 @@ spec:
                   key: PROVIDER_URL
             - name: REPORTER_PORT
               value: "6000"
-            - name: DATA_FEED_REPORTER_CONCURRENCY
-              value: 20
           {{ end }}
           command: ["yarn"]
           args: [start:reporter:vrf]


### PR DESCRIPTION
This PR fixes https://github.com/Bisonai/orakl-helm-charts/pull/15 where `DATA_FEED_REPORTER_CONCURRENCY` was set to wrong chart.