### PR TITLE
(BAOBAB) Add type: LoadBalancer to the service of new Grafana

### DIFF
--- a/grafana-as-code/templates/service.yaml
+++ b/grafana-as-code/templates/service.yaml
@@ -10,3 +10,4 @@ spec:
       protocol: TCP
       port: 80
       targetPort: 3000
+  type: LoadBalancer


### PR DESCRIPTION
The Kubernetes has services: `ClusterIP`, `NodePort`, `LoadBalancer`, `ExternalName`. I set the service type to `ClusterIP` as the default value because I want to open the new Grafana only inside our network. However, `ClusterIP` is only valid for communication between pods.

Therefore, an external IP address will be assigned when this PR is merged. Once it's assigned, I'll modify our firewall to allow requests only through OVPN.