### PR TITLE
(BAOBAB) GOAPI remove start command for goapi

### DIFF
--- a/goapi/templates/deployment.yaml
+++ b/goapi/templates/deployment.yaml
@@ -64,8 +64,6 @@ spec:
                 secretKeyRef:
                   name: goapi-secrets
                   key: REDIS_PORT
-          command: ["yarn"]
-          args: ["start:prod"]
           ports:
           - name: http
             containerPort: 3030


### PR DESCRIPTION
Remove start command for nodejs api
Now expected to follow default image command as followed
`CMD ["sh", "-c", "migrate -database \"${DATABASE_URL}&sslmode=disable\" -verbose -path ./migrations up && apibin"]`