### PR TITLE
(cypress) Update CI Helm Lint workflow to include pull request events

### DIFF
--- a/.github/workflows/ci.helm-lint.yaml
+++ b/.github/workflows/ci.helm-lint.yaml
@@ -6,9 +6,7 @@ on:
     types:
       - opened
     branches:
-      - main
       - gcp-cypress-prod
-      - gcp-baobab-prod
 
 jobs:
   lint:

--- a/.github/workflows/ci.helm-lint.yaml
+++ b/.github/workflows/ci.helm-lint.yaml
@@ -1,0 +1,48 @@
+name: CI Helm Lint
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+      - gcp-cypress-prod
+      - gcp-baobab-prod
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run Helm lint
+        uses: WyriHaximus/github-action-helm3@v3
+        id: lint
+        with:
+          exec: |
+            failed_services=""
+            for file in $(git diff --name-only HEAD~1..HEAD); do
+              dir=$(dirname $file)
+              if [ -f "$dir/Chart.yaml" ]; then
+                if ! helm lint $dir; then
+                  failed_services+="'$(basename $dir)', "
+                fi
+              fi
+            done
+
+            if [ -n "$failed_services" ]; then
+              # Remove the trailing comma and space
+              failed_services=${failed_services%??}
+              echo "failed_services=$failed_services" >> $GITHUB_OUTPUT
+            fi
+
+      - name: Failed services
+        if: steps.lint.outputs.failed_services
+        run: |
+          echo "Failed services: ${{ steps.lint.outputs.failed_services }}"
+          exit 1


### PR DESCRIPTION
This pull request updates the CI Helm Lint workflow to include pull request events. It adds a new job called "lint". The job checks out the repository and runs Helm lint on all changed files. If any service fails the linting process, the job outputs the names of the failed services. This update ensures that the CI Helm Lint workflow is triggered for pull request events and provides information about failed services.