### PR TITLE
(CYPRESS) godelegator deployment

### DIFF
--- a/godelegator/Chart.yaml
+++ b/godelegator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: orakl-godelegator
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.0.1.20240229.0732.a084a43"

--- a/godelegator/templates/deployment.yaml
+++ b/godelegator/templates/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+  labels:
+    app: {{ .Values.deployment.name }}
+    app.kubernetes.io/name: {{ .Values.deployment.name }}
+    app.kubernetes.io/instance: {{ .Values.deployment.name }}
+spec:
+  replicas: {{ .Values.godelegator.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.deployment.name }}
+      app.kubernetes.io/name: {{ .Values.deployment.name }}
+      app.kubernetes.io/instance: {{ .Values.deployment.name }}
+  template:
+    metadata:
+      {{- with .Values.global.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ .Values.deployment.name }}
+        app.kubernetes.io/name: {{ .Values.deployment.name }}
+        app.kubernetes.io/instance: {{ .Values.deployment.name }}
+    spec:
+      {{- with .Values.global.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.deployment.name }}-{{ .Values.godelegator.serviceAccount.name }}
+      securityContext:
+        {{- toYaml .Values.godelegator.podSecurityContext | nindent 8 }}
+      {{- if .Values.global.affinity.enabled }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: {{ .Values.global.affinity.key }}
+                operator: In
+                values:
+                - {{ .Values.global.affinity.value }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.godelegator.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: godelegator-secrets
+                  key: DATABASE_URL
+            - name: USE_GOOGLE_SECRET_MANAGER
+              value: "true"
+            - name: GOOGLE_SECRET_PATH
+              value: "projects/1003113141257/secrets/orakl-cypress-fee-payer"
+            - name: APP_PORT
+              value: "5050"
+          ports:
+          - name: http
+            containerPort: 5050
+            protocol: TCP
+          {{- if .Values.global.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.global.livenessProbe.path }}
+              port: 5050
+            initialDelaySeconds: {{ .Values.global.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.global.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.global.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.global.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.global.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.global.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.global.readinessProbe.path }}
+              port: 5050
+            initialDelaySeconds: {{ .Values.global.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.global.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.global.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.global.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.global.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.godelegator.resources | nindent 12 }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/godelegator/templates/deployment.yaml
+++ b/godelegator/templates/deployment.yaml
@@ -60,16 +60,16 @@ spec:
             - name: GOOGLE_SECRET_PATH
               value: "projects/1003113141257/secrets/orakl-cypress-fee-payer"
             - name: APP_PORT
-              value: "5050"
+              value: "{{ .Values.service.port }}"
           ports:
           - name: http
-            containerPort: 5050
+            containerPort: {{ .Values.service.port }}
             protocol: TCP
           {{- if .Values.global.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.global.livenessProbe.path }}
-              port: 5050
+              port: {{ .Values.service.port }} 
             initialDelaySeconds: {{ .Values.global.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.global.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.global.livenessProbe.timeoutSeconds }}
@@ -80,7 +80,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.global.readinessProbe.path }}
-              port: 5050
+              port: {{ .Values.service.port }}
             initialDelaySeconds: {{ .Values.global.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.global.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.global.readinessProbe.timeoutSeconds }}

--- a/godelegator/templates/sa.yaml
+++ b/godelegator/templates/sa.yaml
@@ -4,7 +4,4 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.deployment.name }}-{{ .Values.godelegator.serviceAccount.name }}
   labels: {{ .Values.deployment.name }}
-  # TODO: This annotation should be sync with GCP SA email injected from GH actions
-  # annotations:
-  # iam.gke.io/gcp-service-account: <Here>
 {{- end }}

--- a/godelegator/templates/sa.yaml
+++ b/godelegator/templates/sa.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.global.secretManager -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.deployment.name }}-{{ .Values.godelegator.serviceAccount.name }}
+  labels: {{ .Values.deployment.name }}
+  # TODO: This annotation should be sync with GCP SA email injected from GH actions
+  # annotations:
+  # iam.gke.io/gcp-service-account: <Here>
+{{- end }}

--- a/godelegator/templates/service.yaml
+++ b/godelegator/templates/service.yaml
@@ -5,10 +5,12 @@ metadata:
 spec:
   # type: ClusterIP
   ports:
-    - port: 5050
+    - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
   type: LoadBalancer
-  loadBalancerIP: 34.126.65.247
+  {{- if .Values.service.loadBalancerIP}}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   selector:
     app: {{ .Values.deployment.name }}

--- a/godelegator/templates/service.yaml
+++ b/godelegator/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.deployment.name }}
+spec:
+  # type: ClusterIP
+  ports:
+    - port: 5050
+      targetPort: http
+      protocol: TCP
+  type: LoadBalancer
+  loadBalancerIP: 34.126.65.247
+  selector:
+    app: {{ .Values.deployment.name }}

--- a/godelegator/values.yaml
+++ b/godelegator/values.yaml
@@ -1,0 +1,66 @@
+global:
+  image:
+    repository: public.ecr.aws/bisonai/orakl-godelegator #repository url
+    pullPolicy: IfNotPresent
+    tag: "v0.0.1.20240229.0732.a084a43"
+    imagePullPolicy: IfNotPresent
+    # -- If defined, uses a Secret to pull an image from a private Docker registry or repository
+    imagePullSecrets: []
+
+  secretManager:
+    enabled: true
+    secretId:
+    versionId:
+
+  affinity:
+    enabled: false
+    key: kubernetes.io/hostname
+    value:
+
+  podAnnotations:
+
+  livenessProbe:
+    enabled: true
+    path: /api/v1/
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+
+  readinessProbe:
+    enabled: true
+    path: /api/v1/
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+
+godelegator:
+  enabled: true
+  replicas: 1
+  serviceAccount:
+    create: true
+    name: sa
+    annotations: {}
+    automountServiceAccountToken: true
+
+  podSecurityContext: {}
+  containerSecurityContext: {}
+
+# update limits later
+# resources:
+#   limits:
+#     cpu: 500m
+#     memory: 1Gi
+#   requests:
+#     cpu: 500m
+#     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+dotenv: {}
+deployment:
+  name: orakl-godelegator
+  replicas: 1

--- a/godelegator/values.yaml
+++ b/godelegator/values.yaml
@@ -1,4 +1,7 @@
 global:
+  name: godelegator
+  namespace: orakl
+
   image:
     repository: public.ecr.aws/bisonai/orakl-godelegator #repository url
     pullPolicy: IfNotPresent
@@ -64,3 +67,8 @@ dotenv: {}
 deployment:
   name: orakl-godelegator
   replicas: 1
+
+service:
+  port: 5050
+  # Optional: For fix external IP address
+  loadBalancerIP: 34.126.65.247

--- a/manifest/argocd/cypress/godelegator.yaml
+++ b/manifest/argocd/cypress/godelegator.yaml
@@ -11,5 +11,5 @@ spec:
   source:
     path: godelegator/
     repoURL: https://github.com/Bisonai/orakl-helm-charts.git
-    targetRevision: gcp-baobab-prod
+    targetRevision: gcp-cypress-prod
   syncPolicy: {}

--- a/manifest/argocd/cypress/godelegator.yaml
+++ b/manifest/argocd/cypress/godelegator.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: godelegator
+  namespace: argocd
+spec:
+  destination:
+    namespace: orakl
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: godelegator/
+    repoURL: https://github.com/Bisonai/orakl-helm-charts.git
+    targetRevision: gcp-baobab-prod
+  syncPolicy: {}

--- a/secret-store/godelegator-secret.yaml
+++ b/secret-store/godelegator-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: godelegator-secrets
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: cypress/godelegator
+        property: DATABASE_URL


### PR DESCRIPTION
### Updates compared to baobab helmchart codes
1. env variable related to google secret manager not in vault anymore
2. removal of env variable `PROVIDER_URL`. (refer:https://github.com/Bisonai/orakl/pull/1201)
3. commented resource limit from `values.yaml`

> vault & argocd manifest has been all set up