### PR TITLE
Unify namings and minor change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.aider*

--- a/aggregator/README.md
+++ b/aggregator/README.md
@@ -1,29 +1,4 @@
-## Request-Response Settings for Orakl ##
+## Aggregator Settings for Orakl ##
 ---
 
-
-This chart will deploy the Request-Response of Orakl.
-
-
-``` bash
-global:
-  image:
-    repository: docker.io/jolol/orakl #repository url
-    pullPolicy: IfNotPresent
-    tag: "v.0.0.6"                    #image tag
-    imagePullPolicy: IfNotPresent
-    # -- If defined, uses a Secret to pull an image from a private Docker registry or repository
-    imagePullSecrets: []
-
-  config:
-    NODE_ENV: production    #[dev, production]
-    CHAIN: baobab           #[baobab, cypress]
-    HOST_SETTINGS_DB_DIR:   #Default is empty
-    HEALTH_CHECK_PORT: 8888 #Specify Helath Check Port
-    ORAKL_DIR: /app/db      #The path should match with PVC of Orakl database
-    REDIS_HOST: localhost   #Redis Host Url
-    REDIS_PORT: 6379        #Redis Port
-    SLACK_WEBHOOK_URL:      #Error message is delivered to slack 
-    LOG_LEVEL: debug        #[info, debug]
-    LOG_DIR: /app/log       #The path should match with PVC of Orakl Log
-    ```   
+This chart will deploy the Aggregator of Orakl.

--- a/aggregator/templates/listener/deployment-listener.yaml
+++ b/aggregator/templates/listener/deployment-listener.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-listener
+  name: {{ .Values.global.name }}-listener
   labels:
     {{- include "orakl-aggregator.labels.listener" . | nindent 4 }}
 spec:

--- a/aggregator/templates/listener/deployment-listener.yaml
+++ b/aggregator/templates/listener/deployment-listener.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aggregator-listener
+  name: {{ .Values.name }}-listener
   labels:
     {{- include "orakl-aggregator.labels.listener" . | nindent 4 }}
 spec:

--- a/aggregator/templates/listener/service.yaml
+++ b/aggregator/templates/listener/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: aggregator-listener
+  name: {{ .Values.name }}-listener
   labels: 
     {{- include "orakl-aggregator.labels.listener" . | nindent 4 }}  
 spec:

--- a/aggregator/templates/listener/service.yaml
+++ b/aggregator/templates/listener/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-listener
+  name: {{ .Values.global.name }}-listener
   labels: 
     {{- include "orakl-aggregator.labels.listener" . | nindent 4 }}  
 spec:

--- a/aggregator/templates/reporter/deployment-reporter.yaml
+++ b/aggregator/templates/reporter/deployment-reporter.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aggregator-reporter
+  name: {{ .Values.name }}-reporter
   labels:
     {{- include "orakl-aggregator.labels.reporter" . | nindent 4 }}
 spec:

--- a/aggregator/templates/reporter/deployment-reporter.yaml
+++ b/aggregator/templates/reporter/deployment-reporter.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-reporter
+  name: {{ .Values.global.name }}-reporter
   labels:
     {{- include "orakl-aggregator.labels.reporter" . | nindent 4 }}
 spec:

--- a/aggregator/templates/reporter/service.yaml
+++ b/aggregator/templates/reporter/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: aggregator-reporter
+  name: {{ .Values.name }}-reporter
   labels: 
     {{- include "orakl-aggregator.labels.reporter" . | nindent 4 }}  
 spec:

--- a/aggregator/templates/reporter/service.yaml
+++ b/aggregator/templates/reporter/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-reporter
+  name: {{ .Values.global.name }}-reporter
   labels: 
     {{- include "orakl-aggregator.labels.reporter" . | nindent 4 }}  
 spec:

--- a/aggregator/templates/worker/deployment-worker.yaml
+++ b/aggregator/templates/worker/deployment-worker.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-worker
+  name: {{ .Values.global.name }}-worker
   labels:
     {{- include "orakl-aggregator.labels.worker" . | nindent 4 }}
 spec:

--- a/aggregator/templates/worker/deployment-worker.yaml
+++ b/aggregator/templates/worker/deployment-worker.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aggregator-worker
+  name: {{ .Values.name }}-worker
   labels:
     {{- include "orakl-aggregator.labels.worker" . | nindent 4 }}
 spec:

--- a/aggregator/templates/worker/service.yaml
+++ b/aggregator/templates/worker/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: aggregator-worker
+  name: {{ .Values.name }}-worker
   labels: 
     {{- include "orakl-aggregator.labels.worker" . | nindent 4 }}  
 spec:

--- a/aggregator/templates/worker/service.yaml
+++ b/aggregator/templates/worker/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-worker
+  name: {{ .Values.global.name }}-worker
   labels: 
     {{- include "orakl-aggregator.labels.worker" . | nindent 4 }}  
 spec:

--- a/aggregator/values.baobab.yaml
+++ b/aggregator/values.baobab.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: aggregator
+  name: orakl-aggregator
   namespace: orakl
   appName: orakl-aggregator
   image:

--- a/aggregator/values.cypress.yaml
+++ b/aggregator/values.cypress.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: aggregator
+  name: orakl-aggregator
   namespace: orakl
   appName: orakl-aggregator
   image:

--- a/aggregator/values.yaml
+++ b/aggregator/values.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: aggregator
+  name: orakl-aggregator
   namespace: orakl
   appName: orakl-aggregator
   image:

--- a/api/values.baobab.yaml
+++ b/api/values.baobab.yaml
@@ -1,7 +1,7 @@
 ## Klaytn Orakl Api Configuration
 ## created by Bisonai
 global:
-  name: api
+  name: orakl-api
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-api

--- a/api/values.cypress.yaml
+++ b/api/values.cypress.yaml
@@ -1,7 +1,7 @@
 ## Klaytn Orakl Api Configuration
 ## created by Bisonai
 global:
-  name: api
+  name: orakl-api
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-api

--- a/api/values.yaml
+++ b/api/values.yaml
@@ -1,7 +1,7 @@
 ## Klaytn Orakl Api Configuration
 ## created by Bisonai
 global:
-  name: api
+  name: orakl-api
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-api

--- a/boot-api/values.baobab.yaml
+++ b/boot-api/values.baobab.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: boot-api
+  name: orakl-boot-api
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-boot-api #repository url

--- a/boot-api/values.yaml
+++ b/boot-api/values.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: boot-api
+  name: orakl-boot-api
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-boot-api #repository url

--- a/cli/templates/deployment.yaml
+++ b/cli/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cli
+  name: {{ .Values.global.name }} 
   labels:
     {{- include "orakl-cli.labels.cli" . | nindent 4 }}
 spec:

--- a/cli/values.baobab.yaml
+++ b/cli/values.baobab.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: cli
+  name: orakl-cli
   namespace: orakl
   image:
     repository: public.ecr.aws/u6t6w0e4/orakl-cli

--- a/cli/values.cypress.yaml
+++ b/cli/values.cypress.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: cli
+  name: orakl-cli
   namespace: orakl
   image:
     repository: public.ecr.aws/u6t6w0e4/orakl-cli

--- a/cli/values.yaml
+++ b/cli/values.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: cli
+  name: orakl-cli
   namespace: orakl
   image:
     repository: public.ecr.aws/u6t6w0e4/orakl-cli

--- a/delegator/values.baobab.yaml
+++ b/delegator/values.baobab.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: delegator
+  name: orakl-delegator
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-delegator #repository url

--- a/delegator/values.cypress.yaml
+++ b/delegator/values.cypress.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: delegator
+  name: orakl-delegator
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-delegator #repository url

--- a/delegator/values.yaml
+++ b/delegator/values.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: delegator
+  name: orakl-delegator
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-delegator #repository url

--- a/fetcher/templates/deployment.yaml
+++ b/fetcher/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fetcher
+  name: {{ .Values.global.name }} 
   labels:
     {{- include "orakl-fetcher.labels.fetcher" . | nindent 4 }}
 spec:

--- a/fetcher/templates/service.yaml
+++ b/fetcher/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: orakl-fetcher
+  name: {{ .Values.global.name }} 
 spec:
   {{ if .Values.global.externalIp.enabled }}
   type: LoadBalancer

--- a/fetcher/values.baobab.yaml
+++ b/fetcher/values.baobab.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: fetcher
+  name: orakl-fetcher
   namespace: orakl
   image:
     repository: public.ecr.aws/u6t6w0e4/orakl-fetcher #repository url

--- a/fetcher/values.cypress.yaml
+++ b/fetcher/values.cypress.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: fetcher
+  name: orakl-fetcher
   namespace: orakl
   image:
     repository: public.ecr.aws/u6t6w0e4/orakl-fetcher #repository url

--- a/fetcher/values.yaml
+++ b/fetcher/values.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: fetcher
+  name: orakl-fetcher
   namespace: orakl
   image:
     repository: public.ecr.aws/u6t6w0e4/orakl-fetcher #repository url

--- a/grafana-as-code/values.baobab.yaml
+++ b/grafana-as-code/values.baobab.yaml
@@ -1,5 +1,5 @@
 global:
-  name: grafana-as-code
+  name: orakl-grafana-as-code
   namespace: orakl
 
 image:

--- a/grafana-as-code/values.cypress.yaml
+++ b/grafana-as-code/values.cypress.yaml
@@ -1,5 +1,5 @@
 global:
-  name: grafana-as-code
+  name: orakl-grafana-as-code
   namespace: orakl
 
 image:

--- a/grafana-as-code/values.yaml
+++ b/grafana-as-code/values.yaml
@@ -1,5 +1,5 @@
 global:
-  name: grafana-as-code
+  name: orakl-grafana-as-code
   namespace: orakl
 
 image:

--- a/monitor-api/templates/deployment.yaml
+++ b/monitor-api/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: monitor-api
+  name: {{ .Values.global.name }} 
   labels:
     {{- include "orakl-monitor-api.labels.monitor-api" . | nindent 4 }}
 spec:

--- a/monitor-api/templates/secrets.yaml.bak
+++ b/monitor-api/templates/secrets.yaml.bak
@@ -1,9 +1,0 @@
-# apiVersion: mumoshu.github.io/v1alpha1
-# kind: AWSSecret
-# metadata:
-#   name: orakl-monitor-secrets
-# spec:
-#   stringDataFrom:
-#     secretsManagerSecretRef:
-#       secretId: orakl/infra
-#       versionId: 1ac113f0-b90c-4b2a-b104-fced527fcf06

--- a/monitor-api/templates/service.yaml
+++ b/monitor-api/templates/service.yaml
@@ -4,7 +4,9 @@ metadata:
   name: orakl-monitor-api
 spec:
   type: LoadBalancer
-  loadBalancerIP: 34.142.143.138
+  {{- with .Values.service }}
+  loadBalancerIP: {{ .loadBalancerIP | quote }}
+  {{- end }}
   ports:
     - port: 8888
       targetPort: http

--- a/monitor-api/templates/service.yaml
+++ b/monitor-api/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: orakl-monitor-api
+  name: {{ .Values.global.name }} 
 spec:
   type: LoadBalancer
   {{- with .Values.service }}

--- a/monitor-api/values.baobab.yaml
+++ b/monitor-api/values.baobab.yaml
@@ -1,7 +1,7 @@
 ## Klaytn Orakl Listener Configuration
 ## created by Bisonai
 global:
-  name: monitor-api
+  name: orakl-monitor-api
   namespace: orakl
 
   image:

--- a/monitor-api/values.cypress.yaml
+++ b/monitor-api/values.cypress.yaml
@@ -1,7 +1,7 @@
 ## Klaytn Orakl Listener Configuration
 ## created by Bisonai
 global:
-  name: monitor-api
+  name: orakl-monitor-api
   namespace: orakl
 
   image:

--- a/monitor-api/values.yaml
+++ b/monitor-api/values.yaml
@@ -1,7 +1,7 @@
 ## Klaytn Orakl Listener Configuration
 ## created by Bisonai
 global:
-  name: monitor-api
+  name: orakl-monitor-api
   namespace: orakl
 
   image:

--- a/node/values.baobab.yaml
+++ b/node/values.baobab.yaml
@@ -1,7 +1,7 @@
 ## Klaytn Orakl Api Configuration
 ## created by Bisonai
 global:
-  name: node
+  name: orakl-node
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-node

--- a/node/values.yaml
+++ b/node/values.yaml
@@ -1,7 +1,7 @@
 ## Klaytn Orakl Api Configuration
 ## created by Bisonai
 global:
-  name: node
+  name: orakl-node
   namespace: orakl
   image:
     repository: public.ecr.aws/bisonai/orakl-node

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "license": "UNLICENSED",
   "devDependencies": {
     "husky": "^9.0.11"
   }

--- a/request-response/README.md
+++ b/request-response/README.md
@@ -1,29 +1,4 @@
 ## Request-Response Settings for Orakl ##
 ---
 
-
 This chart will deploy the Request-Response of Orakl.
-
-
-``` bash
-global:
-  image:
-    repository: docker.io/jolol/orakl #repository url
-    pullPolicy: IfNotPresent
-    tag: "v.0.0.6"                    #image tag
-    imagePullPolicy: IfNotPresent
-    # -- If defined, uses a Secret to pull an image from a private Docker registry or repository
-    imagePullSecrets: []
-
-  config:
-    NODE_ENV: production    #[dev, production]
-    CHAIN: baobab           #[baobab, cypress]
-    HOST_SETTINGS_DB_DIR:   #Default is empty
-    HEALTH_CHECK_PORT: 8888 #Specify Helath Check Port
-    ORAKL_DIR: /app/db      #The path should match with PVC of Orakl database
-    REDIS_HOST: localhost   #Redis Host Url
-    REDIS_PORT: 6379        #Redis Port
-    SLACK_WEBHOOK_URL:      #Error message is delivered to slack 
-    LOG_LEVEL: debug        #[info, debug]
-    LOG_DIR: /app/log       #The path should match with PVC of Orakl Log
-    ```   

--- a/request-response/templates/listener/deployment-listener.yaml
+++ b/request-response/templates/listener/deployment-listener.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: request-response-listener
+  name: {{ .Values.global.name }}-listener
   labels:
     {{- include "orakl-request-response.labels.listener" . | nindent 4 }}
 spec:

--- a/request-response/templates/listener/service.yaml
+++ b/request-response/templates/listener/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: request-response-listener
+  name: {{ .Values.global.name }}-listener
   labels: 
     {{- include "orakl-request-response.labels.listener" . | nindent 4 }}
 spec:

--- a/request-response/templates/reporter/deployment-reporter.yaml
+++ b/request-response/templates/reporter/deployment-reporter.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: request-response-reporter
+  name: {{ .Values.global.name }}-reporter
   labels:
     {{- include "orakl-request-response.labels.reporter" . | nindent 4 }}
 spec:

--- a/request-response/templates/reporter/service.yaml
+++ b/request-response/templates/reporter/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: request-response-reporter
+  name: {{ .Values.global.name }}-reporter
   labels: 
     {{- include "orakl-request-response.labels.reporter" . | nindent 4 }}
 spec:

--- a/request-response/templates/worker/deployment-worker.yaml
+++ b/request-response/templates/worker/deployment-worker.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: request-response-worker
+  name: {{ .Values.global.name }}-worker
   labels:
     {{- include "orakl-request-response.labels.worker" . | nindent 4 }}
 spec:

--- a/request-response/templates/worker/service.yaml
+++ b/request-response/templates/worker/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: request-response-worker
+  name: {{ .Values.global.name }}-worker
   labels: 
     {{- include "orakl-request-response.labels.worker" . | nindent 4 }}
 spec:

--- a/request-response/values.baobab.yaml
+++ b/request-response/values.baobab.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: request-response
+  name: orakl-request-response
   namespace: orakl
 
   appName: orakl-request-response

--- a/request-response/values.cypress.yaml
+++ b/request-response/values.cypress.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: request-response
+  name: orakl-request-response
   namespace: orakl
 
   appName: orakl-request-response

--- a/request-response/values.yaml
+++ b/request-response/values.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: request-response
+  name: orakl-request-response
   namespace: orakl
 
   appName: orakl-request-response

--- a/vrf/README.md
+++ b/vrf/README.md
@@ -1,0 +1,1 @@
+## Orakl VRF ##

--- a/vrf/templates/listener/deployment-listener.yaml
+++ b/vrf/templates/listener/deployment-listener.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vrf-listener
+  name: {{ .Values.global.name }}-listener
   labels:
     {{- include "orakl-vrf.labels.listener" . | nindent 4 }}
 spec:

--- a/vrf/templates/listener/service.yaml
+++ b/vrf/templates/listener/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vrf-listener
+  name: {{ .Values.global.name }}-listener
   labels: 
     {{- include "orakl-vrf.labels.listener" . | nindent 4 }}  
 spec:

--- a/vrf/templates/reporter/deployment-reporter.yaml
+++ b/vrf/templates/reporter/deployment-reporter.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vrf-reporter
+  name: {{ .Values.global.name }}-reporter
   labels:
     {{- include "orakl-vrf.labels.reporter" . | nindent 4 }}
 spec:

--- a/vrf/templates/reporter/service.yaml
+++ b/vrf/templates/reporter/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vrf-reporter
+  name: {{ .Values.global.name }}-reporter
   labels: 
     {{- include "orakl-vrf.labels.reporter" . | nindent 4 }}  
 spec:

--- a/vrf/templates/worker/deployment-worker.yaml
+++ b/vrf/templates/worker/deployment-worker.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vrf-worker
+  name: {{ .Values.global.name }}-worker
   labels:
     {{- include "orakl-vrf.labels.worker" . | nindent 4 }}
 spec:

--- a/vrf/templates/worker/service.yaml
+++ b/vrf/templates/worker/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vrf-worker
+  name: {{ .Values.global.name }}-worker
   labels: 
     {{- include "orakl-vrf.labels.worker" . | nindent 4 }}  
 spec:

--- a/vrf/values.baobab.yaml
+++ b/vrf/values.baobab.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: vrf
+  name: orakl-vrf
   namespace: orakl
 
   appName: orakl-vrf

--- a/vrf/values.cypress.yaml
+++ b/vrf/values.cypress.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: vrf
+  name: orakl-vrf
   namespace: orakl
 
   appName: orakl-vrf

--- a/vrf/values.yaml
+++ b/vrf/values.yaml
@@ -2,7 +2,7 @@
 ## created by Bisonai
 
 global:
-  name: vrf
+  name: orakl-vrf
   namespace: orakl
 
   appName: orakl-vrf


### PR DESCRIPTION
- Unify every Orakl services to have prefix `orakl-`.
- Changed assign external IP address of`orakl-monitor-api` method:
  - before: Write `loadBalancerIP` directly into `./template/service.yaml` file.
  - after: Write `service.loadBalancerIP` in values file.
  
Please ignore CI failed. I think it's not working properly. Because I passed to lint in my local machine. And also it's can generate(`--dry-run`).
