### PR TITLE
deploy baobab-cli-v0.6.1.20240507.0716.2268213

### DIFF
--- a/cli/Chart.yaml
+++ b/cli/Chart.yaml
@@ -3,4 +3,4 @@ name: orakl-cli
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.2
-appVersion: "v0.6.1.20240411.1128.5a6190e"
+appVersion: "v0.6.1.20240507.0716.2268213"

--- a/cli/values.yaml
+++ b/cli/values.yaml
@@ -7,7 +7,7 @@ global:
   image:
     repository: public.ecr.aws/u6t6w0e4/orakl-cli
     pullPolicy: IfNotPresent
-    tag: "v0.6.1.20240411.1128.5a6190e"
+    tag: "v0.6.1.20240507.0716.2268213"
     imagePullPolicy: IfNotPresent
     # -- If defined, uses a Secret to pull an image from a private Docker registry or repository
     imagePullSecrets: []


### PR DESCRIPTION
baobab-cli-v0.6.1.20240507.0716.2268213
### Manually add .js extension to relative imports
 Closes #1454 

# Description

We are using ES modules in the `cli` workspace and currently, most if not all of our imports in the cli workspace don't include the file extension, which is a requirement in ES modules. Since tsc doesn't add .js extension during compilation, there is a `module not found` error when we try to run `node dist/index.js`. 

This PR:

-  manually adds `.js` extensions to all imports
-  adds an `eslint-plugin-import` package to provide linting error suggestions when imported file extension is not provided (ignores the test dir)

I've tested running the cli executable after these implementations and the `module not found` error has been resolved.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image

 - PR: 1455