### PR TITLE
(OraklNode) Increase cypress cpu limits and requests

### DIFF
--- a/node/values.cypress.yaml
+++ b/node/values.cypress.yaml
@@ -88,10 +88,10 @@ node:
   containerSecurityContext: {}
   resources:
     limits:
-      cpu: 3000m
+      cpu: 4000m
       memory: 2Gi
     requests:
-      cpu: 3000m
+      cpu: 4000m
       memory: 2Gi
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
3000m -> 4000m for 40+ price pair increase preparation