### PR TITLE
fix(loki): set fsGroupChangePolicy=OnRootMismatch to stop full-volume chown on every restart

### DIFF
--- a/loki/values.baobab.yaml
+++ b/loki/values.baobab.yaml
@@ -54,6 +54,23 @@ persistence:
 loki:
   auth_enabled: false
 
+  # Same as the chart default, except for fsGroupChangePolicy. The chart
+  # renders this block with `toYaml`, so every key must be repeated here.
+  #
+  # Without `OnRootMismatch`, kubelet recursively chowns the whole volume on
+  # every pod start because fsGroup is set. This volume holds ~42k chunk files
+  # on NFS, so each restart stalls the pod in ContainerCreating for many
+  # minutes while `pod_workers.go` logs
+  #   "unmounted volumes=[storage] ... context deadline exceeded"
+  # even though the CSI mount already succeeded. `OnRootMismatch` skips the
+  # walk when the volume root already has the right ownership.
+  podSecurityContext:
+    fsGroup: 10001
+    fsGroupChangePolicy: OnRootMismatch
+    runAsGroup: 10001
+    runAsNonRoot: true
+    runAsUser: 10001
+
   server:
     http_listen_port: 3100
 


### PR DESCRIPTION
Follow-up to #592, found while recovering `loki-0` after today's baobab node outage.

## Symptom

`loki-0` sat in `ContainerCreating` for 20+ minutes on every restart. kubelet logged, on a loop:

```
E pod_workers.go:1298] "Error syncing pod, skipping"
  err="unmounted volumes=[storage], unattached volumes=[], failed to process volumes=[]: context deadline exceeded"
  pod="monitoring/loki-0"
```

This looks like a broken volume mount, and it sent me down a long path of unmounting stale NFS mounts, restarting `csi-nfs-node`, and restarting kubelet. **None of that was the problem** — the CSI driver logged `NodePublishVolume ... succeeded` on every single attempt, and the mount was present on the node each time.

## Actual cause

One earlier line in the kubelet log is the real signal:

```
W volume_linux.go:49] Setting volume ownership for
  /var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~csi/pvc-c78ea62d-.../mount
  and fsGroup set. If the volume has a lot of files then setting volume
  ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699
```

The chart sets `fsGroup: 10001`, and Kubernetes' default `fsGroupChangePolicy` is `Always`. So on **every** pod start kubelet walks the whole volume and `chown`s it. This volume currently holds **41,882 chunk files** and lives on NFS, so the walk takes many minutes. Meanwhile the pod worker's 2-minute context deadline expires on each sync loop and prints the misleading `unmounted volumes=[storage]` error.

## Fix

Set `fsGroupChangePolicy: OnRootMismatch`, so kubelet checks the volume root's ownership and skips the recursive walk when it already matches (which it does after the first successful chown).

The chart renders this via `securityContext: {{- toYaml .Values.loki.podSecurityContext }}`, so the block replaces the chart default wholesale — the other four keys are repeated verbatim and only `fsGroupChangePolicy` is new.

## Verification

`helm template` on the `loki` (single-binary) StatefulSet:

```yaml
      securityContext:
        fsGroup: 10001
        fsGroupChangePolicy: OnRootMismatch
        runAsGroup: 10001
        runAsNonRoot: true
        runAsUser: 10001
```

And the rendered ConfigMap `config.yaml` is still byte-identical to the live one, so the retention settings pinned in #592 (`retention_period: 72h`, compactor block) are unaffected.

Apply after merge:

```
helm upgrade --install loki grafana/loki --version 6.41.1 \
  -n monitoring -f loki/values.baobab.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)