### PR TITLE
chore(baobab): move Kaia EN RPC from IDC to BlockPI

### DIFF
--- a/dal/values.baobab.yaml
+++ b/dal/values.baobab.yaml
@@ -73,9 +73,9 @@ dal:
     - name: DAL_API_PORT
       value: "8090"
     - name: KAIA_PROVIDER_URL
-      value: "http://172.0.100.240:8551"
+      value: "https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506"
     - name: KAIA_WEBSOCKET_URL
-      value: "ws://172.0.100.240:8552"
+      value: "wss://kaia-kairos.blockpi.network/v1/ws/3cfd82415a376065d8ce988e77d10ce1a7cf9506"
     - name: SUBMISSION_PROXY_CONTRACT
       value: "0x05ce978f1200bc7243ae4a5968de8c3f8bd082f7"
     - name: REDIS_HOST

--- a/delegator/values.baobab.yaml
+++ b/delegator/values.baobab.yaml
@@ -65,7 +65,7 @@ delegator:
     - name: VAULT_KEY_NAME
       value: delegator
     - name: PROVIDER_URL
-      value: http://172.0.100.240:8551
+      value: https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506
     - name: DATABASE_URL
       value:
     - name: GOMAXPROCS

--- a/monitor-api/values.baobab.yaml
+++ b/monitor-api/values.baobab.yaml
@@ -95,7 +95,7 @@ monitorApi:
     - name: PASSWORD
       value: bisonaicomingsoon
     - name: PROVIDER
-      value: http://172.0.100.240:8551
+      value: https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506
   resources:
     limits:
       memory: 4Gi

--- a/node/values.baobab.yaml
+++ b/node/values.baobab.yaml
@@ -69,7 +69,7 @@ node:
     - name: REDIS_PORT
       value: "6379"
     - name: KAIA_PROVIDER_URL
-      value: "http://172.0.100.240:8551"
+      value: "https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506"
     - name: KAIA_WEBSOCKET_URL
       value: "wss://public-en.node.kaia.io/ws"
     - name: ETH_PROVIDER_URL

--- a/por/values.baobab.yaml
+++ b/por/values.baobab.yaml
@@ -43,7 +43,7 @@ por:
     - name: LOG_LEVEL
       value: "debug"
     - name: POR_PROVIDER_URL
-      value: "http://172.0.100.240:8551"
+      value: "https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506"
     - name: POR_PORT
       value: "3000"
     - name: POR_CHAIN

--- a/reporter/values.baobab.yaml
+++ b/reporter/values.baobab.yaml
@@ -59,9 +59,9 @@ reporter:
     - name: SUBMISSION_PROXY_CONTRACT
       value: "0x05ce978f1200bc7243ae4a5968de8c3f8bd082f7"
     - name: KAIA_PROVIDER_URL
-      value: http://172.0.100.240:8551
+      value: https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506
     - name: KAIA_WEBSOCKET_URL
-      value: ws://172.0.100.230:8552
+      value: wss://kaia-kairos.blockpi.network/v1/ws/3cfd82415a376065d8ce988e77d10ce1a7cf9506
     - name: DELEGATOR_URL
       value: "http://orakl-delegator.orakl.svc.cluster.local"
     - name: GOMAXPROCS

--- a/request-response/values.baobab.yaml
+++ b/request-response/values.baobab.yaml
@@ -28,7 +28,7 @@ global:
     - name: REDIS_PORT
       value: "6379"
     - name: PROVIDER_URL
-      value: http://172.0.100.240:8551
+      value: https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506
 
   secretManager:
     enabled: false

--- a/sentinel/values.baobab.yaml
+++ b/sentinel/values.baobab.yaml
@@ -95,7 +95,7 @@ app:
     - name: EVENT_CHECK_INTERVAL
       value: "60s"
     - name: JSON_RPC_URL
-      value: http://172.0.100.240:8551
+      value: https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506
     - name: ORAKL_API_URL
       value: http://orakl-api.orakl.svc.cluster.local:3030/api/v1
     - name: ORAKL_NODE_ADMIN_URL
@@ -107,7 +107,7 @@ app:
     - name: SUBMISSION_PROXY_CONTRACT
       value: "0x05ce978f1200bc7243ae4a5968de8c3f8bd082f7"
     - name: KAIA_PROVIDER_URL
-      value: "http://172.0.100.240:8551"
+      value: "https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506"
     - name: ACC_ID
       value: "734"
     - name: VRF_KEYHASH

--- a/vrf/values.baobab.yaml
+++ b/vrf/values.baobab.yaml
@@ -28,7 +28,7 @@ global:
     - name: REDIS_PORT
       value: "6379"
     - name: PROVIDER_URL
-      value: http://172.0.100.240:8551
+      value: https://kaia-kairos.blockpi.network/v1/rpc/3cfd82415a376065d8ce988e77d10ce1a7cf9506
 
   secretManager:
     enabled: false


### PR DESCRIPTION
Repoints every **baobab** service off the internal IDC Kaia EN onto BlockPI.

```
http://172.0.100.240:8551  →  https://kaia-kairos.blockpi.network/v1/rpc/<key>
ws://172.0.100.240:8552    →  wss://kaia-kairos.blockpi.network/v1/ws/<key>
```

Kairos = baobab. **Verified live before committing** — both the https and wss endpoints return `chainId 1001`.

## Services (12 env vars, 9 charts)

| chart | var(s) | note |
|---|---|---|
| reporter | KAIA_PROVIDER_URL, KAIA_WEBSOCKET_URL | WS also **un-cross-wires** — see below |
| dal | KAIA_PROVIDER_URL, KAIA_WEBSOCKET_URL | http + ws |
| delegator | PROVIDER_URL | |
| node | KAIA_PROVIDER_URL | http only; its WS + provider_urls DB row are already public, left alone |
| por | POR_PROVIDER_URL | |
| request-response | PROVIDER_URL | |
| sentinel | JSON_RPC_URL **and** KAIA_PROVIDER_URL | two vars |
| vrf | PROVIDER_URL | |
| monitor-api | PROVIDER | in helm but not deployed; updated for consistency |

## Cross-wire fix

`reporter/values.baobab.yaml` had `KAIA_WEBSOCKET_URL = ws://172.0.100.230:8552` — the **cypress** EN — while its HTTP correctly used `.240`. Now points at the baobab BlockPI WS.

## Scope

**helm values only.** No Vault or node-DB change: `secretManager.enabled=false` so these plain env literals are what the pods read, and the node `provider_urls` table holds only public fallbacks (no IDC IP). Confirmed against live baobab pods.

## ⚠️ Deploy

ArgoCD auto-syncs `idc-fly`, so **merging this deploys it to baobab** within a few minutes. This is the intended canary before the cypress (mainnet) PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)