### PR TITLE
chore(cypress): move Kaia EN RPC from IDC to BlockPI

### DIFF
--- a/dal/values.cypress.yaml
+++ b/dal/values.cypress.yaml
@@ -72,7 +72,7 @@ dal:
     - name: KAIA_PROVIDER_URL
       value: "https://freely-inspired-ram.n0des.xyz"
     - name: KAIA_WEBSOCKET_URL
-      value: "ws://172.0.100.230:8552"
+      value: "wss://kaia.blockpi.network/v1/ws/6162552d8a429e7bfc7aeae9420e908062adda5b"
     - name: SUBMISSION_PROXY_CONTRACT
       value: "0xcb56b163e545a3870ca04c6ae2401f2405fb29a9"
     - name: REDIS_HOST

--- a/delegator/values.cypress.yaml
+++ b/delegator/values.cypress.yaml
@@ -64,7 +64,7 @@ delegator:
     - name: VAULT_KEY_NAME
       value: delegator
     - name: PROVIDER_URL
-      value: "http://172.0.100.230:8551"
+      value: "https://kaia.blockpi.network/v1/rpc/6162552d8a429e7bfc7aeae9420e908062adda5b"
     - name: DATABASE_URL
       value:
     - name: GOMAXPROCS

--- a/monitor-api/values.cypress.yaml
+++ b/monitor-api/values.cypress.yaml
@@ -95,7 +95,7 @@ monitorApi:
     - name: PASSWORD
       value: bisonaicomingsoon
     - name: PROVIDER
-      value: http://172.0.100.230:8551
+      value: https://kaia.blockpi.network/v1/rpc/6162552d8a429e7bfc7aeae9420e908062adda5b
   resources:
     limits:
       memory: 4Gi

--- a/por/values.cypress.yaml
+++ b/por/values.cypress.yaml
@@ -43,7 +43,7 @@ por:
     - name: LOG_LEVEL
       value: "debug"
     - name: POR_PROVIDER_URL
-      value: "http://172.0.100.230:8551"
+      value: "https://kaia.blockpi.network/v1/rpc/6162552d8a429e7bfc7aeae9420e908062adda5b"
     - name: POR_PORT
       value: "3000"
     - name: POR_CHAIN

--- a/reporter/values.cypress.yaml
+++ b/reporter/values.cypress.yaml
@@ -59,9 +59,9 @@ reporter:
     - name: SUBMISSION_PROXY_CONTRACT
       value: "0xcb56b163e545a3870ca04c6ae2401f2405fb29a9"
     - name: KAIA_PROVIDER_URL
-      value: "http://172.0.100.230:8551"
+      value: "https://kaia.blockpi.network/v1/rpc/6162552d8a429e7bfc7aeae9420e908062adda5b"
     - name: KAIA_WEBSOCKET_URL
-      value: "wss://172.0.100.230:8552"
+      value: "wss://kaia.blockpi.network/v1/ws/6162552d8a429e7bfc7aeae9420e908062adda5b"
     - name: DELEGATOR_URL
       value: "http://orakl-delegator.orakl.svc.cluster.local"
     - name: GOMAXPROCS

--- a/request-response/values.cypress.yaml
+++ b/request-response/values.cypress.yaml
@@ -28,7 +28,7 @@ global:
     - name: REDIS_PORT
       value: "6379"
     - name: PROVIDER_URL
-      value: "http://172.0.100.230:8551"
+      value: "https://kaia.blockpi.network/v1/rpc/6162552d8a429e7bfc7aeae9420e908062adda5b"
 
   secretManager:
     enabled: false

--- a/sentinel/values.cypress.yaml
+++ b/sentinel/values.cypress.yaml
@@ -94,7 +94,7 @@ app:
     - name: EVENT_CHECK_INTERVAL
       value: "60s"
     - name: JSON_RPC_URL
-      value: "http://172.0.100.230:8551"
+      value: "https://kaia.blockpi.network/v1/rpc/6162552d8a429e7bfc7aeae9420e908062adda5b"
     - name: ORAKL_API_URL
       value: http://orakl-api.orakl.svc.cluster.local:3030/api/v1
     - name: ORAKL_NODE_ADMIN_URL
@@ -106,7 +106,7 @@ app:
     - name: SUBMISSION_PROXY_CONTRACT
       value: "0xcb56b163e545a3870ca04c6ae2401f2405fb29a9"
     - name: KAIA_PROVIDER_URL
-      value: "http://172.0.100.230:8551"
+      value: "https://kaia.blockpi.network/v1/rpc/6162552d8a429e7bfc7aeae9420e908062adda5b"
     - name: ACC_ID
       value: "14"
     - name: VRF_KEYHASH

--- a/vrf/values.cypress.yaml
+++ b/vrf/values.cypress.yaml
@@ -28,7 +28,7 @@ global:
     - name: REDIS_PORT
       value: "6379"
     - name: PROVIDER_URL
-      value: "http://172.0.100.230:8551"
+      value: "https://kaia.blockpi.network/v1/rpc/6162552d8a429e7bfc7aeae9420e908062adda5b"
 
   secretManager:
     enabled: false


### PR DESCRIPTION
Repoints every **cypress (mainnet)** service off the internal IDC Kaia EN onto BlockPI.

```
http://172.0.100.230:8551  →  https://kaia.blockpi.network/v1/rpc/<key>
ws://172.0.100.230:8552    →  wss://kaia.blockpi.network/v1/ws/<key>
```

**Verified live before committing** — both https and wss return `chainId 8217`.

## Services (10 env vars, 8 charts)

| chart | var(s) | note |
|---|---|---|
| reporter | KAIA_PROVIDER_URL, KAIA_WEBSOCKET_URL | http + ws |
| vrf | PROVIDER_URL | |
| request-response | PROVIDER_URL | |
| delegator | PROVIDER_URL | |
| sentinel | JSON_RPC_URL **and** KAIA_PROVIDER_URL | two vars |
| por | POR_PROVIDER_URL | |
| dal | KAIA_WEBSOCKET_URL | ws only; dal not deployed in cypress, http already off-IDC |
| monitor-api | PROVIDER | in helm, not deployed |

**cypress node (Go aggregator) intentionally untouched** — it has no KAIA provider env and reads its RPC from the `provider_urls` DB row, which is already the public endpoint (no IDC IP).

## Scope

helm values only. No Vault / node-DB change (`secretManager.enabled=false`; DB holds only public fallbacks). Confirmed against live cypress pods.

## ⚠️ Mainnet — merge AFTER baobab

ArgoCD auto-syncs `idc-fly`, so **merging this repoints the live mainnet oracle RPC** within minutes. Recommend merging **#594 (baobab) first**, verifying reporter submissions + sentinel health stay green, then merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)