### PR TITLE
chore(cypress): bump node image for kucoin/mexc fetcher fixes

### DIFF
--- a/node/values.cypress.yaml
+++ b/node/values.cypress.yaml
@@ -6,7 +6,7 @@ global:
   image:
     repository: public.ecr.aws/bisonai/orakl-node
     pullPolicy: IfNotPresent
-    tag: "v0.0.1.20260526.0533.58da808.cypress"
+    tag: "v0.0.1.20260715.1104.eb73d2a"
     imagePullPolicy: IfNotPresent
     # -- If defined, uses a Secret to pull an image from a private Docker registry or repository
     imagePullSecrets: []


### PR DESCRIPTION
Bumps the **cypress (Bisonai follower)** node image to `v0.0.1.20260715.1104.eb73d2a`, deploying the kucoin (#2510) and mexc (#2511) fetcher fixes.

The running image (`58da808`, 2026-05-26) predates both fixes, so kucoin/mexc feeds are still dead on this node.

- Same network-agnostic image already **running healthy on baobab** (`orakl-node`), where kucoin reconnected (ping observed) and the old 509/blocked errors are gone.
- CHAIN is injected at runtime, so the un-suffixed tag is correct for cypress (this is exactly what `tag+deploy` produces).

⚠️ ArgoCD auto-syncs `idc-fly` → merging rolls the cypress follower node. The **KF leader** (the actual cypress fetcher) is bumped separately in `orakl-helm-charts-kf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)