### PR TITLE
Drop the dead 34.x proxies from the cypress follower node

### DIFF
--- a/node/values.cypress.yaml
+++ b/node/values.cypress.yaml
@@ -71,7 +71,7 @@ node:
     - name: LISTEN_PORT
       value: "10010"
     - name: ETH_PROVIDER_URL
-      value: "http://34.126.104.218:4000"
+      value: "https://ethereum-rpc.publicnode.com"
     - name: ETH_WEBSOCKET_URL
       value: "wss://ethereum-rpc.publicnode.com"
     - name: SUBMISSION_PROXY_CONTRACT
@@ -84,8 +84,6 @@ node:
       value: "http://100.72.39.118:5050"
     - name: HOST_IP
       value: "100.97.79.113"
-    - name: WS_PROXY
-      value: "ws://34.64.220.17:4000"
     - name: GOMAXPROCS
       value: "15"
 


### PR DESCRIPTION
The GCP firewall rules for the follower's proxies were deleted (per GCP's request), so both proxy endpoints on the Bisonai cypress **follower** node are now unreachable:

```
ETH_PROVIDER_URL = http://34.126.104.218:4000   ← dead
WS_PROXY         = ws://34.64.220.17:4000        ← dead (CEX geo-bypass)
```

## Impact (already confirmed)

**On-chain is unaffected.** The KF **leader** produces the global aggregate, never used these proxies (fetches directly / via BlockPI), and has **0 errors in 24h**. The dead proxies only degrade the **follower's** local aggregates and spam its logs (~126 closed-network / ~72 block-number / ~70 slot0 errors/24h).

## Change

| var | before | after |
|---|---|---|
| `ETH_PROVIDER_URL` | `http://34.126.104.218:4000` (dead) | `https://ethereum-rpc.publicnode.com` |
| `WS_PROXY` | `ws://34.64.220.17:4000` (dead) | *removed* |

- ETH_PROVIDER now matches the node's existing `ETH_WEBSOCKET_URL` (publicnode); verified `chainId 1`.
- `WS_PROXY` removed — `wss.WithProxyUrl("")` returns early, so an unset proxy = **direct** CEX connections, which is exactly what the KF leader already does with 0 errors.

⚠️ ArgoCD note: the cypress `node` app has **no auto-sync** (empty syncPolicy), so I'll trigger the sync manually after merge and confirm the follower's proxy errors stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)