### PR TITLE
Bump the cypress node image to v0.0.2 for HashKey support

### DIFF
--- a/node/values.cypress.yaml
+++ b/node/values.cypress.yaml
@@ -6,7 +6,7 @@ global:
   image:
     repository: public.ecr.aws/bisonai/orakl-node
     pullPolicy: IfNotPresent
-    tag: "v0.0.1.20260715.1104.eb73d2a"
+    tag: "v0.0.2.20260721.0817.3c10683"
     imagePullPolicy: IfNotPresent
     # -- If defined, uses a Secret to pull an image from a private Docker registry or repository
     imagePullSecrets: []


### PR DESCRIPTION
Syncs the helm source of truth with the live cypress follower, which was rolled to `v0.0.2.20260721.0817.3c10683` (HashKey Global provider, Bisonai/orakl#2515) via `kubectl set image`. Prevents an ArgoCD sync from reverting to v0.0.1.

GRND-USDT now aggregates gateio + hashkey on-chain ($0.01016, verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)