### PR TITLE
Deploy the grafana-as-code image with the GRND-USDT source fix

### DIFF
--- a/grafana-as-code/values.baobab.yaml
+++ b/grafana-as-code/values.baobab.yaml
@@ -5,7 +5,7 @@ global:
 image:
   repository: asia-southeast1-docker.pkg.dev/vpc-host-orakl-prod/orakl/orakl-grafana
   pullPolicy: IfNotPresent
-  tag: "monitor.v1.0.0.20260713.0510.3fb18c1"
+  tag: "monitor.v1.0.0.20260721.0851.590cfc8"
   imagePullSecrets:
     - name: gar-json-key
 

--- a/grafana-as-code/values.cypress.yaml
+++ b/grafana-as-code/values.cypress.yaml
@@ -5,7 +5,7 @@ global:
 image:
   repository: asia-southeast1-docker.pkg.dev/vpc-host-orakl-prod/orakl/orakl-grafana
   pullPolicy: IfNotPresent
-  tag: "monitor.v1.0.0.20260713.0510.3fb18c1"
+  tag: "monitor.v1.0.0.20260721.0851.590cfc8"
   imagePullSecrets:
     - name: gar-json-key
 


### PR DESCRIPTION
Bumps the grafana-as-code job image to `monitor.v1.0.0.20260721.0851.590cfc8`, built from orakl-grafana#113 (GRND-USDT dashboard sources → gateio + hashkey). ArgoCD runs the job → dashboards refresh in Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)