### PR TITLE
Bump cypress orakl-node image to the crash-safe signer-rotation build

### DIFF
--- a/node/values.cypress.yaml
+++ b/node/values.cypress.yaml
@@ -6,7 +6,7 @@ global:
   image:
     repository: public.ecr.aws/bisonai/orakl-node
     pullPolicy: IfNotPresent
-    tag: "v0.0.2.20260721.0817.3c10683"
+    tag: "v0.0.4.20260727.0639.9e93421"
     imagePullPolicy: IfNotPresent
     # -- If defined, uses a Secret to pull an image from a private Docker registry or repository
     imagePullSecrets: []


### PR DESCRIPTION
## What
Bumps `node/values.cypress.yaml` image tag `v0.0.2.20260721.0817.3c10683` → `v0.0.4.20260727.0639.9e93421` (cypress k8s follower).

## Why
The cypress k8s orakl-node (Raft follower) is **already running** v0.0.4 — deployed today via `kubectl set image` and verified (migration 000041 applied, getSigner `usable=true`, key `0xBe9E…` unchanged, cypress feeds uninterrupted). This brings the declared image in line with the live pod so it is not reverted to the pre-fix **v0.0.2** ([orakl#2516](https://github.com/Bisonai/orakl/issues/2516)).

## ⚠️ Do not blind-sync the cypress `node` ArgoCD app
The app is **separately OutOfSync** on a manual `ETH_PROVIDER_URL=http://34.126.104.218:4000` override on the live pod (idc-fly declares `https://ethereum-rpc.publicnode.com`). A full ArgoCD sync would revert that dedicated-RPC override. This PR **does not touch** it. Until the override is reconciled into GitOps (decide whether the dedicated RPC is intended and, if so, codify it here), deploy the image surgically with `kubectl set image` rather than a full sync.

## Risk
None to the running system — image already live and validated. Declaration-only alignment.